### PR TITLE
Note about tab completion crashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,9 @@ so that you can run functions directly.
    iex(<service>@127.0.0.2)1)> run the command you want
    ```
 
+Note: If hitting tab to autocomplete crashes the remote shell, make sure that
+the local and remote versions of elixir and otp match.
+
 Contributing
 ------------
 


### PR DESCRIPTION
Adds a not about troubleshooting shell crashes, when hitting tab to autocomplete.