### PR TITLE
Fallback search if container ip is empty. Updated install command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Installation
 ------------
 
  * Binaries: [On the releases page](https://github.com/Shimmur/shipspotter/releases)
- * From Source: `go get github.com/Shimmur/shipspotter`
+ * From Source: `go install github.com/Shimmur/shipspotter@latest`
 
 Basic Usage
 -----------

--- a/main.go
+++ b/main.go
@@ -150,13 +150,34 @@ func findContainerByID(client *docker.Client, id string) (*docker.APIContainers,
 	return nil, fmt.Errorf("Unable to match container ID: %s", id)
 }
 
+// fallback if findIPForContainer's container.NetworkSettings.IPAddress is empty
+func findIPInNetworks(networks map[string]docker.ContainerNetwork) (string, error) {
+	var ip string
+	for _, network := range networks {
+		ip = network.IPAddress
+	}
+	if ip == "" {
+		return "", fmt.Errorf("Unable to find Container IP in NetworkSettings")
+	}
+	return ip, nil
+}
+
 func findIPForContainer(client *docker.Client, cntnr *docker.APIContainers) (string, error) {
 	container, err := client.InspectContainer(cntnr.ID)
 	if err != nil {
 		return "", fmt.Errorf("Unable to inspect container: %s", err)
 	}
 
-	ip := container.NetworkSettings.IPAddress
+	var ip string
+	if container.NetworkSettings.IPAddress == "" {
+		ipFromNetworkSettings, err := findIPInNetworks(container.NetworkSettings.Networks)
+		if err != nil {
+			log.Fatal(err)
+		}
+		ip = ipFromNetworkSettings
+	} else {
+		ip = container.NetworkSettings.IPAddress
+	}
 	log.Infof("Container IP address: %s", ip)
 
 	return ip, nil

--- a/main.go
+++ b/main.go
@@ -170,11 +170,11 @@ func findIPForContainer(client *docker.Client, cntnr *docker.APIContainers) (str
 
 	var ip string
 	if container.NetworkSettings.IPAddress == "" {
-		ipFromNetworkSettings, err := findIPInNetworks(container.NetworkSettings.Networks)
+		ipFromNetworks, err := findIPInNetworks(container.NetworkSettings.Networks)
 		if err != nil {
 			log.Fatal(err)
 		}
-		ip = ipFromNetworkSettings
+		ip = ipFromNetworks
 	} else {
 		ip = container.NetworkSettings.IPAddress
 	}


### PR DESCRIPTION
This PR adds a fallback search in containers network settings if the regular container ip is an empty string. 

Without this patch i got an error when using the proxy connection:

`Can't forward traffic to backend tcp/:3306: ssh: rejected: connect failed (Temporary failure in name resolution)`
Docker version 19.03.5, build 633a0ea838 (Remote Host)

I also updated the readme to use go install instead of go get

> go install, with or without a version suffix (as described above), is now the recommended way to build and install packages in module mode. go get should be used with the -d flag to adjust the current module's dependencies without building packages, and use of go get to build and install packages is deprecated. In a future release, the -d flag will always be enabled. (https://tip.golang.org/doc/go1.16#modules)